### PR TITLE
valueEquals static & instance method

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,26 @@ console.log(a == b); // Prints false, which is WRONG
 console.log(a === b); // Prints false, which is WRONG
 ```
 
+#### `Guid.valueEquals(guid1,guid2)`
+
+Returns true, if
+
+- `guid1` is an instance of `Guid`, and
+- `guid1` and `guid2` represent the same GUID value-wise
+
+```javascript
+const a = Guid.parse("c959e321-19df-474c-a2e7-df268dbf3998");
+const b = "c959e321-19df-474c-a2e7-df268dbf3998";
+const c = {
+  toString() {
+    return "c959e321-19df-474c-a2e7-df268dbf3998"
+  }
+}
+
+console.log(a.valueEquals(b)) // Prints true
+console.log(a.valueEquals(c)) // Prints true
+```
+
 #### `Guid.validate(value)`
 Determines if a string or bytes array value represents a valid GUID.
 
@@ -185,6 +205,10 @@ The [the generator function](#the-generator-function) used to generate new
 
 #### `equals(other)`
 Returns true if `other` is Guid and represents the same GUID as this one.
+
+#### `valueEquals(other)`
+
+Returns true if `other?.toString()` returns the string value that is equals to this GUID's string representation
 
 #### `isEmpty()`
 Returns true if the GUID equals to `Guid.EMPTY`, otherwise false.

--- a/src/Guid.ts
+++ b/src/Guid.ts
@@ -179,6 +179,17 @@ export class Guid {
   }
 
   /**
+   * Checks if this {@link Guid} is equals to another value-wise.
+   *
+   * @param {Guid} other
+   * @returns {boolean}
+   */
+  @enumerable(true)
+  public valueEquals(other: Guid): boolean {
+    return this._value === other?.toString();
+  }
+
+  /**
    * Returns true if this {@link Guid} is equals to {@link Guid.EMPTY}.
    * @returns boolean
    */
@@ -338,6 +349,22 @@ export class Guid {
   @enumerable(true)
   public static equals(a: Guid, b: Guid): boolean {
     return Guid.isGuid(a) && a.equals(b);
+  }
+
+  /**
+   * Checks if <tt>a</tt> {@link Guid} equals <tt>b</tt> {@link Guid} value-wise.
+   *
+   * @remarks
+   * This method does a strict type check to see if <tt>a</tt>
+   * is an instance of {@link Guid} but not for <tt>b</tt>.
+   *
+   * @param {Guid} a
+   * @param {Guid} b
+   * @returns {boolean}
+   */
+  @enumerable(true)
+  public static valueEquals(a: Guid, b: Guid): boolean {
+    return Guid.isGuid(a) && a.valueEquals(b);
   }
 
   /**

--- a/tests/instance-methods.spec.ts
+++ b/tests/instance-methods.spec.ts
@@ -20,6 +20,61 @@ describe("Guid.prototype.equals()", () => {
   });
 });
 
+describe("Guid.prototype.valueEquals()", () => {
+  it("returns true if other Guid is the same value-wise", () => {
+    const guid1 = Guid.parse("c4f3a98a-f800-49a1-b90a-84b228c4009f");
+    const guid2 = Guid.parse("c4f3a98a-f800-49a1-b90a-84b228c4009f");
+    const guid4 = Guid.newGuid();
+    const guid6 = Guid.parse(guid4.toString());
+
+    expect(guid1.valueEquals(guid2)).toBeTruthy();
+    expect(guid2.valueEquals(guid1)).toBeTruthy();
+    expect(guid4.valueEquals(guid6)).toBeTruthy();
+  });
+
+  it("returns false if other Guid is not the same value-wise", () => {
+    const guid1 = Guid.parse("c4f3a98a-f800-49a1-b90a-84b228c4009f");
+    const guid2 = Guid.parse("c4f3a98a-f800-49a1-b90a-84b228c4129f");
+    const guid3 = Guid.newGuid();
+    const guid4 = Guid.newGuid();
+
+    expect(guid1.valueEquals(guid2)).toBeFalsy();
+    expect(guid1.valueEquals(guid3)).toBeFalsy();
+    expect(guid1.valueEquals(guid4)).toBeFalsy();
+    expect(guid2.valueEquals(guid3)).toBeFalsy();
+    expect(guid2.valueEquals(guid4)).toBeFalsy();
+    expect(guid3.valueEquals(guid4)).toBeFalsy();
+  });
+
+  it("returns true if other Guid is equals value-wise but not type-wise", () => {
+    const guid1 = Guid.parse("c4f3a98a-f800-49a1-b90a-84b228c4009f");
+    const guid2 = "c4f3a98a-f800-49a1-b90a-84b228c4009f";
+    const guid3 = {
+      toString() {
+        return guid2;
+      }
+    };
+
+    // @ts-ignore
+    expect(guid1.valueEquals(guid2)).toBeTruthy();
+    // @ts-ignore
+    expect(guid1.valueEquals(guid3)).toBeTruthy();
+    // @ts-ignore
+    expect(Guid.parse(guid2).valueEquals(guid3)).toBeTruthy();
+  });
+
+  it("returns false if other Guid is neither equals value-wise nor type-wise", () => {
+    const guid1 = Guid.parse("c4f3a98a-f800-49a1-b90a-84b228c4009f");
+    const guid2 = "c4f3a98a-f800-49a1-b90a-84b228c4009";
+    const guid3 = "c4f3a98a-f800-49a1-b90a-84b228c4009a";
+
+    // @ts-ignore
+    expect(guid1.valueEquals(guid2)).toBeFalsy();
+    // @ts-ignore
+    expect(guid1.valueEquals(guid3)).toBeFalsy();
+  });
+});
+
 describe("Guid.prototype.isEmpty()", () => {
   it("returns true if the Guid is empty", () => {
     const guid1 = Guid.parse("00000000-0000-0000-0000-000000000000");

--- a/tests/static-methods.spec.ts
+++ b/tests/static-methods.spec.ts
@@ -54,3 +54,54 @@ describe("Guid.equals()", () => {
     expect(Guid.equals(guid, function () {})).toBeFalsy();
   });
 });
+
+describe("Guid.valueEquals()", () => {
+  it("returns true if two Guids are the same value-wise", () => {
+    const guid1 = Guid.parse("c4f3a98a-f800-49a1-b90a-84b228c4009f");
+    const guid2 = Guid.parse("c4f3a98a-f800-49a1-b90a-84b228c4009f");
+    const guid4 = Guid.newGuid();
+    const guid6 = Guid.parse(guid4.toString());
+
+    expect(Guid.valueEquals(guid1, guid2)).toBeTruthy();
+    expect(Guid.valueEquals(guid2, guid1)).toBeTruthy();
+    expect(Guid.valueEquals(guid4, guid6)).toBeTruthy();
+  });
+
+  it("returns false if two Guids are not the same value-wise", () => {
+    const guid1 = Guid.parse("c4f3a98a-f800-49a1-b90a-84b228c4009f");
+    const guid2 = Guid.parse("c4f3a98a-f800-49a1-b90a-84b228c4129f");
+    const guid3 = Guid.newGuid();
+    const guid4 = Guid.newGuid();
+
+    expect(Guid.valueEquals(guid1, guid2)).toBeFalsy();
+    expect(Guid.valueEquals(guid3, guid4)).toBeFalsy();
+  });
+
+  it("returns true if second Guid is equals value-wise but not type-wise", () => {
+    const guid1 = Guid.parse("c4f3a98a-f800-49a1-b90a-84b228c4009f");
+    const guid2 = "c4f3a98a-f800-49a1-b90a-84b228c4009f";
+    const guid3 = {
+      toString() {
+        return guid2;
+      }
+    };
+
+    // @ts-ignore
+    expect(Guid.valueEquals(guid1, guid2)).toBeTruthy();
+    // @ts-ignore
+    expect(Guid.valueEquals(guid1, guid3)).toBeTruthy();
+    // @ts-ignore
+    expect(Guid.valueEquals(Guid.parse(guid2), guid3)).toBeTruthy();
+  });
+
+  it("returns false if second Guid is neither equals value-wise nor type-wise", () => {
+    const guid1 = Guid.parse("c4f3a98a-f800-49a1-b90a-84b228c4009f");
+    const guid2 = "c4f3a98a-f800-49a1-b90a-84b228c4009";
+    const guid3 = "c4f3a98a-f800-49a1-b90a-84b228c4009a";
+
+    // @ts-ignore
+    expect(Guid.valueEquals(guid1, guid2)).toBeFalsy();
+    // @ts-ignore
+    expect(Guid.valueEquals(guid1, guid3)).toBeFalsy();
+  });
+});


### PR DESCRIPTION
Closes #137 

Created:
- `Guid.valueEquals(a: Guid, b: Guid)` static method, which checks type for `a` to see if it is an instance of Guid but not for `b`
- `Guid.prototype.valueEquals(other: Guid)` instance method

Both of the methods checks whether the value of the _supposed_ Guids values are equal and return the boolean of the result